### PR TITLE
fix: reduce heartbeat failure log level from error to warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.aliyun.openservices</groupId>
     <artifactId>loghub-client-lib</artifactId>
-    <version>0.6.53</version>
+    <version>0.6.54</version>
     <packaging>jar</packaging>
 
     <name>Aliyun LOG Java Consumer</name>

--- a/src/main/java/com/aliyun/openservices/loghub/client/LogHubClientAdapter.java
+++ b/src/main/java/com/aliyun/openservices/loghub/client/LogHubClientAdapter.java
@@ -226,7 +226,7 @@ public class LogHubClientAdapter {
             if (e.GetHttpCode() >= 200 && e.GetHttpCode() < 500) {
                 throw e;
             }
-            LOG.error("ConsumerGroup {} HeartBeat failed, httpCode: {}, errorCode: {}, errorMessage: {}",
+            LOG.warn("ConsumerGroup {} HeartBeat failed, httpCode: {}, errorCode: {}, errorMessage: {}",
                     consumerGroupName, e.GetHttpCode(), e.GetErrorCode(), e.GetErrorMessage());
         } catch (Exception e) {
             throw e;


### PR DESCRIPTION
## 问题

当 `HeartBeatWithRetry` 遇到网络错误或 500 服务器错误时，会使用 `error` 级别记录日志。由于这些是临时性问题，会自动重试，使用 `error` 级别可能导致告警疲劳。

## 修改

1. 将 `HeartBeatWithRetry` 中的日志级别从 `error` 改为 `warn`
   - 网络错误和 500 错误属于临时性问题，会自动重试
   - 使用 `warn` 级别更合适，减少不必要的告警

2. 版本号从 0.6.53 更新到 0.6.54

## 影响范围

- `LogHubClientAdapter.HeartBeatWithRetry()` 方法
- 对现有功能无影响，仅调整日志级别